### PR TITLE
Return layer description if present

### DIFF
--- a/service/geoserver_service.py
+++ b/service/geoserver_service.py
@@ -126,26 +126,38 @@ def build_subcategory(store_name, layers):
 def build_layer_from_data_store(layer, workspace_name):
     feature_type = get(layer['href'])['featureType']
     if feature_type['enabled'] and (feature_type.get('advertised') is not None and feature_type['advertised']):
-        return {'name': workspace_name + ':' + layer['name'], 'title': layer['name']}
+        response = {'name': workspace_name + ':' + feature_type['name'], 'title': feature_type['name']}
+        if feature_type.get('abstract') is not None:
+            response['description'] = feature_type['abstract']
+        return response
     return
 
 
 def build_layer_from_coverage_store(layer, workspace_name):
     coverage = get(layer['href'])['coverage']
     if coverage['enabled'] and (coverage.get('advertised') is not None and coverage['advertised']):
-        return {'name': workspace_name + ':' + layer['name'], 'title': layer['name']}
+        response = {'name': workspace_name + ':' + coverage['name'], 'title': coverage['name']}
+        if coverage.get('abstract') is not None:
+            response['description'] = coverage['abstract']
+        return response
     return
 
 
 def build_layer_from_wms_store(layer, workspace_name):
     wmsLayer = get(layer['href'])['wmsLayer']
     if wmsLayer['enabled'] and (wmsLayer.get('advertised') is not None and wmsLayer['advertised']):
-        return {'name': workspace_name + ':' + layer['name'], 'title': layer['name']}
+        response = {'name': workspace_name + ':' + wmsLayer['name'], 'title': wmsLayer['name']}
+        if wmsLayer.get('abstract') is not None:
+            response['description'] = wmsLayer['abstract']
+        return response
     return
 
 
 def build_layer_from_wmts_store(layer, workspace_name):
     wmtsLayer = get(layer['href'])['wmtsLayer']
     if wmtsLayer['enabled'] and (wmtsLayer.get('advertised') is not None and wmtsLayer['advertised']):
-        return {'name': workspace_name + ':' + layer['name'], 'title': layer['name']}
+        response = {'name': workspace_name + ':' + wmtsLayer['name'], 'title': wmtsLayer['name']}
+        if wmtsLayer.get('abstract') is not None:
+            response['description'] = wmtsLayer['abstract']
+        return response
     return


### PR DESCRIPTION
Ejemplo de respuesta con el agregado del campo `description`, borré la descripción que agregó Mati a estaciones_subte solo para mostrar que en caso de que una capa no tenga descripción, el middle no agrega el campo.

```
[
    {
        "name": "Dep.Informatica",
        "subcategories": [
            {
                "name": "informatica",
                "layers": [
                    {
                        "name": "Dep.Informatica:comunas",
                        "title": "comunas",
                        "description": "Información geográfica de la locación (perímetro y área) de las comunas de la Ciudad establecidas a partir de la Ley Orgánica de Comunas (Ley Nº 1777/2005)."
                    }
                ]
            }
        ]
    },
    {
        "name": "DepAgrimensura",
        "subcategories": [
            {
                "name": "datos_agrim",
                "layers": [
                    {
                        "name": "DepAgrimensura:callejero",
                        "title": "callejero",
                        "description": "Listado de las calles de la Ciudad con su referencia geográfica. Además se incluyen propuestas para utilizar estos datos en QGIS y para Open Street Routing Machine (OSRM)"
                    }
                ]
            },
            {
                "name": "datos_agrim2",
                "layers": [
                    {
                        "name": "DepAgrimensura:estaciones_subte",
                        "title": "estaciones_subte"
                    }
                ]
            }
        ]
    }
]
```